### PR TITLE
fix: add `accountId` to `Wallet` class

### DIFF
--- a/frontend/near-wallet.js
+++ b/frontend/near-wallet.js
@@ -23,6 +23,7 @@ export class Wallet {
   wallet;
   network;
   createAccessKeyFor;
+  accountId;
 
   constructor({ createAccessKeyFor = undefined, network = 'testnet' }) {
     // Login to a wallet passing a contractId will create a local


### PR DESCRIPTION
Line 49: `accountId` does not exist on type `Wallet`