### PR TITLE
Update near-wallet.js - avoid hardcoded `testnet` value

### DIFF
--- a/frontend/near-wallet.js
+++ b/frontend/near-wallet.js
@@ -30,7 +30,7 @@ export class Wallet {
     // Omitting the accountId will result in the user being
     // asked to sign all transactions.
     this.createAccessKeyFor = createAccessKeyFor
-    this.network = 'testnet'
+    this.network = network
   }
 
   // To be called when the website loads


### PR DESCRIPTION
Use `network` parameter from constructor