### PR TITLE
Minor file path updates inside `frontend/index.html` to match project structure

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -66,7 +66,7 @@
         </li>
         <li>
           Ultimately, this <code>contract</code> code is defined in
-          <code>assembly/index.ts</code> – this is the source code for your
+          <code>contract/src/contract.ts</code> – this is the source code for your
           <a target="_blank" href="https://docs.near.org/docs/develop/contracts/overview">smart contract</a>.
         </li>
         <li>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,7 +60,7 @@
       </p>
       <ol>
         <li>
-          Look in <code>index.js</code> and <code>near-api.js</code> – you'll see <code>get_greeting</code>
+          Look in <code>frontend/index.js</code> – you'll see <code>get_greeting</code>
           and <code>set_greeting</code> being called on <code>contract</code>.
           What's this?
         </li>
@@ -71,7 +71,7 @@
         </li>
         <li>
           When you run <code>npm run dev</code>, the code in
-          <code>assembly/index.ts</code> gets deployed to the NEAR testnet. You
+          <code>contract/src/contract.ts</code> gets deployed to the NEAR testnet. You
           can see how this happens by looking in <code>package.json</code> at the
           <code>scripts</code> section to find the <code>dev</code> command.
         </li>


### PR DESCRIPTION
The file paths in the `frontend/index.html` markup did not match the correct locations within the project structure.